### PR TITLE
[1.14.4] Updated to 1.14.4 and uses the config system properly

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
-version_forge=26.0.55
-version_minecraft=1.14.2
+version_forge=28.0.2
+version_minecraft=1.14.4
 version_major=0
 version_minor=1
 version_revis=0
-version_mappings=20190623-1.14.2
+version_mappings=20190720-1.14.3
 curse_project_id=272515
 repo=way2muchnoise/BetterAdvancements
 org.gradle.daemon=false

--- a/src/main/java/betteradvancements/BetterAdvancements.java
+++ b/src/main/java/betteradvancements/BetterAdvancements.java
@@ -6,7 +6,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
-import net.minecraftforge.fml.loading.FMLPaths;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -18,9 +18,7 @@ public class BetterAdvancements {
     public BetterAdvancements() {
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, Config.CLIENT);
 
-        Config.instance.loadConfig(Config.CLIENT, FMLPaths.CONFIGDIR.get().resolve(ID + "-client.toml"));
-        MinecraftForge.EVENT_BUS.register(Config.instance);
-
+        FMLJavaModLoadingContext.get().getModEventBus().register(Config.instance);
         MinecraftForge.EVENT_BUS.register(GuiOpenHandler.instance);
     }
 }

--- a/src/main/java/betteradvancements/advancements/BetterDisplayInfoRegistry.java
+++ b/src/main/java/betteradvancements/advancements/BetterDisplayInfoRegistry.java
@@ -7,7 +7,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.world.ServerWorld;
+import net.minecraft.world.server.ServerWorld;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 

--- a/src/main/java/betteradvancements/config/Config.java
+++ b/src/main/java/betteradvancements/config/Config.java
@@ -19,22 +19,6 @@ public class Config {
 
     public static final ForgeConfigSpec CLIENT = ConfigValues.build();
 
-    public void loadConfig(ForgeConfigSpec spec, Path path) {
-        BetterAdvancements.log.debug("Loading config file {}", path);
-
-        final CommentedFileConfig configData = CommentedFileConfig.builder(path)
-            .sync()
-            .autosave()
-            .writingMode(WritingMode.REPLACE)
-            .build();
-
-        BetterAdvancements.log.debug("Built TOML config for {}", path.toString());
-        configData.load();
-        BetterAdvancements.log.debug("Loaded TOML config file {}", path.toString());
-        spec.setConfig(configData);
-        ConfigValues.pushChanges();
-    }
-
     @SubscribeEvent
     public void onLoad(final ModConfig.Loading configEvent) {
         BetterAdvancements.log.debug("Loaded {} config file {}", BetterAdvancements.ID, configEvent.getConfig().getFileName());
@@ -44,6 +28,7 @@ public class Config {
     @SubscribeEvent
     public void onFileChange(final ModConfig.ConfigReloading configEvent) {
         BetterAdvancements.log.debug("Reloaded {} config file {}", BetterAdvancements.ID, configEvent.getConfig().getFileName());
+        ((CommentedFileConfig)configEvent.getConfig().getConfigData()).load();
         ConfigValues.pushChanges();
     }
 }

--- a/src/main/java/betteradvancements/gui/BetterAdvancementEntryGui.java
+++ b/src/main/java/betteradvancements/gui/BetterAdvancementEntryGui.java
@@ -57,7 +57,7 @@ public class BetterAdvancementEntryGui extends AbstractGui {
         this.y = this.betterDisplayInfo.getPosY() != null ? this.betterDisplayInfo.getPosY() : MathHelper.floor(displayInfo.getY() * 27.0F);
         this.refreshHover();
         // this.screenScale = mc.mainWindow.getScaleFactor(0);
-        this.screenScale = mc.mainWindow.func_216521_a(0, false);
+        this.screenScale = mc.mainWindow.calcGuiScale(0, false);
     }
 
     private void refreshHover() {

--- a/src/main/java/betteradvancements/util/FolderUtil.java
+++ b/src/main/java/betteradvancements/util/FolderUtil.java
@@ -3,7 +3,7 @@ package betteradvancements.util;
 import betteradvancements.BetterAdvancements;
 import net.minecraft.item.crafting.RecipeManager;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.world.ServerWorld;
+import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModList;
 import org.apache.commons.io.IOUtils;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,7 +1,7 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[25,)" #mandatory (24 is current forge version)
+loaderVersion="[28,)" #mandatory (24 is current forge version)
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]] #mandatory
 # The modid of the mod


### PR DESCRIPTION
Updated to a newer mapping and fixed import change in 1.14.4.

Fixed the config to use the MOD event bus and thus fixing it.
You are able to save the file and see the changes in-game, hovering the advancements and saving the file with a change updates immediately.
For this to work outside dev you need #67, didn't include it in this or this in that because you might want to update that version before releasing 1.14.4 update. Also avoids merge conflicts with this getting merged.