### PR TITLE
[B.A.] Adding Compatibility with Public Gui Announcement

### DIFF
--- a/src/main/resources/assets/betteradvancements/load_screens/pga_compat.json
+++ b/src/main/resources/assets/betteradvancements/load_screens/pga_compat.json
@@ -1,0 +1,8 @@
+{
+	"screens" : [{
+			"COMMENT" : "BETTER ADVANCEMENTS SUPPORT", 
+			"class" : "betteradvancements.gui.BetterAdvancementsScreen", 
+			"texture" : "publicguiannouncement:textures/gui/advancements_menu.png", 
+			"fullSize" : 255
+		}]
+}


### PR DESCRIPTION
the PGA :
https://www.curseforge.com/minecraft/mc-mods/public-gui-announcement

The Wiki on how these JSON files work :
https://github.com/ArtixAllMighty/PublicGuiAnnouncement/wiki/Add-Mod-Compatibility

In this PR is contained one json file to add compatibility with the mod Public Gui Announcement.
I wanted to ship the compat at first with my mod, but it would be better if the author maintains it himself. (in case of path and name changes as well addition or removal from screens).

I hereby give you all files needed to add compatibility to my mod. There is nothing else left to do apart from merging the PR.

If you have any other question, I'd be happy to answer !

ps : no texture file has been provided : the path specified is for using the minecraft default advancement gui screen (its a screenshot thereof) that has been provided by Public Gui Announcement