### PR TITLE
update to 1.20.4

### DIFF
--- a/Common/src/main/java/betteradvancements/common/gui/BetterAdvancementTab.java
+++ b/Common/src/main/java/betteradvancements/common/gui/BetterAdvancementTab.java
@@ -81,7 +81,7 @@ public class BetterAdvancementTab {
         guiGraphics.enableScissor(left, top, left + width, top + height);
         guiGraphics.pose().pushPose();
         guiGraphics.pose().translate(left, top, 0);
-        ResourceLocation resourcelocation = Objects.requireNonNullElse(this.display.getBackground(), TextureManager.INTENTIONAL_MISSING_TEXTURE);
+        ResourceLocation resourcelocation = this.display.getBackground().orElse(TextureManager.INTENTIONAL_MISSING_TEXTURE);
 
         int i = this.scrollX % 16;
         int j = this.scrollY % 16;

--- a/Common/src/main/java/betteradvancements/common/gui/BetterAdvancementWidget.java
+++ b/Common/src/main/java/betteradvancements/common/gui/BetterAdvancementWidget.java
@@ -81,7 +81,7 @@ public class BetterAdvancementWidget implements IBetterAdvancementEntryGui {
         this.description = Language.getInstance().getVisualOrder(
             this.findOptimalLines(ComponentUtils.mergeStyles(
                 displayInfo.getDescription().copy(),
-                Style.EMPTY.withColor(displayInfo.getFrame().getChatColor())
+                Style.EMPTY.withColor(displayInfo.getType().getChatColor())
             ), maxWidth));
 
         for (FormattedCharSequence line : this.description) {
@@ -227,7 +227,7 @@ public class BetterAdvancementWidget implements IBetterAdvancementEntryGui {
 
             RenderUtil.setColor(betterDisplayInfo.getIconColor(advancementState));
             RenderSystem.enableBlend();
-            guiGraphics.blitSprite(advancementState.frameSprite(this.displayInfo.getFrame()), scrollX + this.x + 3, scrollY + this.y, ICON_SIZE, ICON_SIZE);
+            guiGraphics.blitSprite(advancementState.frameSprite(this.displayInfo.getType()), scrollX + this.x + 3, scrollY + this.y, ICON_SIZE, ICON_SIZE);
             RenderUtil.setColor(betterDisplayInfo.defaultIconColor());
             guiGraphics.renderFakeItem(this.displayInfo.getIcon(), scrollX + this.x + 8, scrollY + this.y + 5);
         }
@@ -336,7 +336,7 @@ public class BetterAdvancementWidget implements IBetterAdvancementEntryGui {
         }
         // Advancement icon
         RenderUtil.setColor(betterDisplayInfo.getIconColor(stateIcon));
-        guiGraphics.blitSprite(stateIcon.frameSprite(this.displayInfo.getFrame()), scrollX + this.x + 3, scrollY + this.y, ICON_SIZE, ICON_SIZE);
+        guiGraphics.blitSprite(stateIcon.frameSprite(this.displayInfo.getType()), scrollX + this.x + 3, scrollY + this.y, ICON_SIZE, ICON_SIZE);
         RenderUtil.setColor(betterDisplayInfo.defaultIconColor());
 
         if (drawLeft) {

--- a/NeoForge/src/main/resources/META-INF/mods.toml
+++ b/NeoForge/src/main/resources/META-INF/mods.toml
@@ -25,7 +25,7 @@ Improvements to the advancements screen.
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
 [[dependencies.betteradvancements]]
 modId="neoforge" #mandatory
-mandatory=true #mandatory
+type="required" #mandatory
 versionRange="${neoforgeVersionRange}" #mandatory
 # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
 ordering="NONE"
@@ -34,7 +34,7 @@ side="CLIENT"
 
 [[dependencies.betteradvancements]]
 modId="minecraft" #mandatory
-mandatory=true #mandatory
+type="required" #mandatory
 versionRange="${minecraftVersionRange}" #mandatory
 # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
 ordering="NONE"

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,31 +15,31 @@ githubUrl=https://github.com/way2muchnoise/BetterAdvancements
 platforms=fabric,forge,neoforge
 
 # Minecraft
-minecraftVersion=1.20.2
-minecraftVersionRange=[1.20, 1.21)
+minecraftVersion=1.20.4
+minecraftVersionRange=[1.20.3, 1.21)
 
 # Forge
-forgeVersion=48.1.0
-loaderVersionRange=[48,)
-forgeVersionRange=[48.0.0,)
+forgeVersion=49.0.14
+loaderVersionRange=[49,)
+forgeVersionRange=[49.0.0,)
 
 # Fabric
-fabricVersion=0.91.2+1.20.2
+fabricVersion=0.92.0+1.20.4
 fabricLoaderVersion=0.15.3
 
 # NeoForge
-neoforgeVersion=20.2.88
+neoforgeVersion=20.4.76-beta
 neoforgeLoaderVersionRange=[1,)
-neoforgeVersionRange=[20.2.0,)
+neoforgeVersionRange=[20.4.0,)
 
 # Fabric Config screen
-clothVersion=12.0.119
-modMenuVersion=8.0.1
+clothVersion=13.0.121
+modMenuVersion=9.0.0
 
 # Mappings
 mappingsChannel=parchment
-mappingsParchmentMinecraftVersion=1.20.2
-mappingsParchmentVersion=2023.12.10
+mappingsParchmentMinecraftVersion=1.20.3
+mappingsParchmentVersion=2023.12.31
 
 # Publishing
 curseProjectId=272515


### PR DESCRIPTION
Modified: 
* gradle.props for Fabric/Forge/Neoforge
* Updated to loom 1.4 (required for building with recent fabric that includes mixin-extra)
* Updated to Gradle 8.3 (required by loom 1.4) 
* Fixed an issue with loom subprojects management (see https://github.com/FabricMC/fabric-loom/issues/856#issuecomment-1501201607)
* Fixed ItemStack icons being rendered under the gui (due to the change with BlitSprite in 1.20.2?)
* Fixed custom colors being applied to the ItemStacks (presumably why the code had the ICON_OFFSET+2 offset, but that didn't work to prevent blending, and caused icons to disapear undet he gui element, as said above, so now just reseting the color to white instead)

Tested:
* Fabric: ✅ 
* NeoForge: ✅ 

Not tested:
* Forge:❓ 

