### PR TITLE
bugfix: blitSprite would cause icons to render under the frame in 1.20.2

### DIFF
--- a/Common/src/main/java/betteradvancements/advancements/BetterDisplayInfo.java
+++ b/Common/src/main/java/betteradvancements/advancements/BetterDisplayInfo.java
@@ -214,6 +214,10 @@ public class BetterDisplayInfo implements IBetterDisplayInfo {
         return state == AdvancementWidgetType.OBTAINED ? getCompletedIconColor() : getUnCompletedIconColor();
     }
 
+    public int defaultIconColor() {
+        return WHITE;
+    }
+
     public int getTitleYMultiplier(AdvancementWidgetType state) {
         if (hasCustomTitleColor()) {
             return 3;

--- a/Common/src/main/java/betteradvancements/gui/BetterAdvancementWidget.java
+++ b/Common/src/main/java/betteradvancements/gui/BetterAdvancementWidget.java
@@ -229,7 +229,8 @@ public class BetterAdvancementWidget implements IBetterAdvancementEntryGui {
 
             RenderUtil.setColor(betterDisplayInfo.getIconColor(advancementState));
             RenderSystem.enableBlend();
-            guiGraphics.blitSprite(advancementState.frameSprite(this.displayInfo.getFrame()), scrollX + this.x + 3, scrollY + this.y, ICON_OFFSET + ICON_SIZE * betterDisplayInfo.getIconYMultiplier(advancementState), ICON_SIZE, ICON_SIZE);
+            guiGraphics.blitSprite(advancementState.frameSprite(this.displayInfo.getFrame()), scrollX + this.x + 3, scrollY + this.y, ICON_SIZE, ICON_SIZE);
+            RenderUtil.setColor(betterDisplayInfo.defaultIconColor());
             guiGraphics.renderFakeItem(this.displayInfo.getIcon(), scrollX + this.x + 8, scrollY + this.y + 5);
         }
 
@@ -337,7 +338,8 @@ public class BetterAdvancementWidget implements IBetterAdvancementEntryGui {
         }
         // Advancement icon
         RenderUtil.setColor(betterDisplayInfo.getIconColor(stateIcon));
-        guiGraphics.blitSprite(stateIcon.frameSprite(this.displayInfo.getFrame()), scrollX + this.x + 3, scrollY + this.y, ICON_OFFSET + ICON_SIZE * betterDisplayInfo.getIconYMultiplier(stateIcon), ICON_SIZE, ICON_SIZE);
+        guiGraphics.blitSprite(stateIcon.frameSprite(this.displayInfo.getFrame()), scrollX + this.x + 3, scrollY + this.y, ICON_SIZE, ICON_SIZE);
+        RenderUtil.setColor(betterDisplayInfo.defaultIconColor());
 
         if (drawLeft) {
             guiGraphics.drawString(this.minecraft.font, this.title, drawX + 5, scrollY + this.y + 9, -1);

--- a/Common/src/main/java/betteradvancements/gui/BetterAdvancementsScreenButton.java
+++ b/Common/src/main/java/betteradvancements/gui/BetterAdvancementsScreenButton.java
@@ -9,6 +9,7 @@ import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import org.jetbrains.annotations.NotNull;
 
 
 public class BetterAdvancementsScreenButton extends AbstractButton {
@@ -19,7 +20,7 @@ public class BetterAdvancementsScreenButton extends AbstractButton {
     }
 
     @Override
-    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {
+    public void renderWidget(@NotNull GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {
         if (this.visible)
         {
             Minecraft mc  = Minecraft.getInstance();


### PR DESCRIPTION
### Target 1.20.2, bugfix the following two issue

1. ItemStack icons would render under the frame (or partially under) due to miscalculated offset in blitSprite (new in 1.20.2)
2. ItemStack icons would be color blended with custom colors (whatever the value of the offset provided in blitSprite)

### Solution

1. Use blitSprite without an offset (it works as intended)
2. Reset color blending to white (that also fixes multiple colors blending in text etc at some other places) 

### History

This is extracted from pr #148 because mod author wants to do the gradle work for 1.20.4 in a different way. 