### PR TITLE
Added ability to translate criteria

### DIFF
--- a/Common/src/main/java/betteradvancements/common/gui/BetterAdvancementWidget.java
+++ b/Common/src/main/java/betteradvancements/common/gui/BetterAdvancementWidget.java
@@ -69,7 +69,7 @@ public class BetterAdvancementWidget implements IBetterAdvancementEntryGui {
         }
         int titleWidth = 29 + mc.font.width(this.title) + k;
         BetterAdvancementsScreen screen = betterAdvancementTabGui.getScreen();
-        this.criterionGrid = CriterionGrid.findOptimalCriterionGrid(this.advancementNode.advancement(), advancementProgress, screen.width / 2, mc.font);
+        this.criterionGrid = CriterionGrid.findOptimalCriterionGrid(this.advancementNode.holder(), this.advancementNode.advancement(), advancementProgress, screen.width / 2, mc.font);
         int maxWidth;
         
         if (!CriterionGrid.requiresShift || Screen.hasShiftDown()) {

--- a/Common/src/main/java/betteradvancements/common/gui/BetterAdvancementsScreenButton.java
+++ b/Common/src/main/java/betteradvancements/common/gui/BetterAdvancementsScreenButton.java
@@ -27,7 +27,7 @@ public class BetterAdvancementsScreenButton extends AbstractButton {
             this.isHovered = mouseX >= this.getX() && mouseY >= this.getY() && mouseX < this.getX() + this.getWidth() && mouseY < this.getY() + this.getHeight();
             guiGraphics.blit(Resources.Gui.TABS, this.getX(), this.getY(), 56, 0, 28, 32);
             if (this.isHovered) {
-                guiGraphics.renderTooltip(mc.font, Component.literal("Advancements"), mouseX, mouseY);
+                guiGraphics.renderTooltip(mc.font, Component.translatable("gui.advancements"), mouseX, mouseY);
             }
             RenderSystem.defaultBlendFunc();
             guiGraphics.renderFakeItem(new ItemStack(Items.BOOK), this.getX() + 6, this.getY() + 10);

--- a/Common/src/main/java/betteradvancements/common/util/CriterionGrid.java
+++ b/Common/src/main/java/betteradvancements/common/util/CriterionGrid.java
@@ -2,6 +2,7 @@ package betteradvancements.common.util;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.advancements.Criterion;
 import net.minecraft.advancements.CriterionProgress;
@@ -81,7 +82,7 @@ public class CriterionGrid {
 
     // Of all the possible grids whose aspect ratio is less than the maximum, this method returns the one with the smallest number of rows.
     // If there is no such grid, this method returns a single-column grid.
-    public static CriterionGrid findOptimalCriterionGrid(Advancement advancement, AdvancementProgress progress, int maxWidth, Font font) {
+    public static CriterionGrid findOptimalCriterionGrid(AdvancementHolder holder, Advancement advancement, AdvancementProgress progress, int maxWidth, Font font) {
         if (progress == null || progress.isDone() || detailLevel.equals(CriteriaDetail.OFF)) {
             return CriterionGrid.empty;
         }
@@ -93,10 +94,11 @@ public class CriterionGrid {
         List<String> cellContents = new ArrayList<>();
         for (String criterion : criteria.keySet()) {
             CriterionProgress criterionProgress = progress.getCriterion(criterion);
+            String criterionKey = "betteradvancements.criterion." + holder.id() + "." + criterion;
             if (criterionProgress != null && criterionProgress.isDone()) {
                 if (detailLevel.showObtained()) {
                     MutableComponent text = Component.literal(" + ").withStyle(ChatFormatting.GREEN);
-                    MutableComponent text2 = Component.literal(criterion).withStyle(ChatFormatting.WHITE);
+                    MutableComponent text2 = Component.translatableWithFallback(criterionKey, criterion).withStyle(ChatFormatting.WHITE);
                     text.append(text2);
                     cellContents.add(text.getString());
                 }
@@ -104,7 +106,7 @@ public class CriterionGrid {
             else {
                 if (detailLevel.showUnobtained()) {
                     MutableComponent text = Component.literal(" x ").withStyle(ChatFormatting.DARK_RED);
-                    MutableComponent text2 = Component.literal(criterion).withStyle(ChatFormatting.WHITE);
+                    MutableComponent text2 = Component.translatableWithFallback(criterionKey, criterion).withStyle(ChatFormatting.WHITE);
                 	text.append(text2);
                     cellContents.add(text.getString());
                 }
@@ -114,7 +116,7 @@ public class CriterionGrid {
 
         if (!detailLevel.showUnobtained()) {
             MutableComponent text = Component.literal(" x ").withStyle(ChatFormatting.DARK_RED);
-            MutableComponent text2 = Component.literal(numUnobtained + " remaining").withStyle(ChatFormatting.WHITE, ChatFormatting.ITALIC);
+            MutableComponent text2 = Component.translatable("betteradvancements.remaining", numUnobtained).withStyle(ChatFormatting.WHITE, ChatFormatting.ITALIC);
         	text.append(text2);
             cellContents.add(text.getString());
         }

--- a/Common/src/main/resources/assets/betteradvancements/lang/en_us.json
+++ b/Common/src/main/resources/assets/betteradvancements/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "betteradvancements.remaining": "%d remaining"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,4 +47,4 @@ curseHomepageLink=https://www.curseforge.com/minecraft/mc-mods/better-advancemen
 modrinthProjectId=Q2OqKxDG
 
 # Version
-specificationVersion=0.4.1
+specificationVersion=0.4.2


### PR DESCRIPTION
Added the ability to translate the criteria using the vanilla localization system. Solves #112
I also localized the `x remaining` string and the advancement button.

If the key doesn't exist it falls back to the criterion name.
The translation key is constructed like this:
```
betteradvancements.criterion.<advancement id>.<criterion name>
```

For example:
```yml
# Advancement
minecraft:adventure/adventuring_time

# Criterion
minecraft:beach

# Becomes
betteradvancements.criterion.minecraft:adventure/adventuring_time.minecraft:beach
```
```json
{
    "betteradvancements.criterion.minecraft:adventure/adventuring_time.minecraft:beach": "Beach"
}
```
