### PR TITLE
config not found fix for ConfigFileHandler.java

### DIFF
--- a/Fabric/src/main/java/betteradvancements/fabric/config/ConfigFileHandler.java
+++ b/Fabric/src/main/java/betteradvancements/fabric/config/ConfigFileHandler.java
@@ -22,8 +22,13 @@ import java.io.IOException;
 public class ConfigFileHandler {
     public static void readFromConfig() {
         JsonObject root = new JsonObject();
-        try (FileReader file = new FileReader(getConfigFile())) {
-            root = JsonParser.parseReader(file).getAsJsonObject();
+        try {
+            File configFile = getConfigFile();
+            if (!configFile.exists()) {
+                writeToConfig();
+                configFile = getConfigFile();
+            }
+            root = JsonParser.parseReader(new FileReader(configFile)).getAsJsonObject();
         } catch (IOException e) {
             Constants.log.error(e);
         }
@@ -106,7 +111,7 @@ public class ConfigFileHandler {
         }
     }
 
-    public static File getConfigFile() {
+    public static File getConfigFile() throws IOException {
         return FabricLoader.getInstance().getConfigDir().resolve("betteradvancements.json").toFile();
     }
 }


### PR DESCRIPTION
Backported fix from [7d961a2](https://github.com/way2muchnoise/BetterAdvancements/commit/7d961a26be737b03861565227ba3a4f6b8c2db35#diff-73361f4a47a2214336d4e28a147bf6098bb667bf751021765dd520ac547d4490L6) to the 1.20.1 branch

create config file for fabric if it doesn't exist
