### PR TITLE
Set fabric mod environment to "client"

### DIFF
--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -14,7 +14,7 @@
     },
     "license": "\"Don't Be a Jerk\" non-commercial care-free license",
       "icon": "icon.png",
-    "environment": "*",
+    "environment": "client",
     "entrypoints": {
       "client" : [
         "betteradvancements.fabric.BetterAdvancements"


### PR DESCRIPTION
Set the fabric mod environment to "client", matching the mod metadata of Forge/Neoforge and just increasing clarity in general.