### PR TITLE
Fix Forge event registration for 1.21.6+

### DIFF
--- a/Forge/src/main/java/betteradvancements/forge/BetterAdvancements.java
+++ b/Forge/src/main/java/betteradvancements/forge/BetterAdvancements.java
@@ -22,7 +22,7 @@ public class BetterAdvancements {
 
         if (FMLEnvironment.dist == Dist.CLIENT) {
             context.registerConfig(ModConfig.Type.CLIENT, Config.CLIENT);
-            context.getModBusGroup().register(MethodHandles.publicLookup(), Config.instance);
+            context.getModBusGroup().register(MethodHandles.lookup(), Config.instance);
             MinecraftForge.EVENT_BUS.register(GuiOpenHandler.instance);
         }
     }


### PR DESCRIPTION
Made #214 some time ago. Hasn't been fixed yet so here's the PR.

Closes #214, #218, #219
Backport to 1.21.6 will close #211