### PR TITLE
update to MC 26.2

### DIFF
--- a/Common/src/main/java/betteradvancements/common/gui/BetterAdvancementTab.java
+++ b/Common/src/main/java/betteradvancements/common/gui/BetterAdvancementTab.java
@@ -3,6 +3,7 @@ package betteradvancements.common.gui;
 import betteradvancements.common.advancements.BetterDisplayInfo;
 import betteradvancements.common.advancements.BetterDisplayInfoRegistry;
 import com.google.common.collect.Maps;
+import com.mojang.datafixers.util.Pair;
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.advancements.AdvancementNode;
 import net.minecraft.advancements.DisplayInfo;
@@ -14,7 +15,6 @@ import net.minecraft.core.ClientAsset;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.Mth;
-import net.minecraft.util.Tuple;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.Map;
@@ -22,7 +22,7 @@ import java.util.Optional;
 
 public class BetterAdvancementTab {
     public static boolean doFade = true;
-    public static final Map<AdvancementHolder, Tuple<Integer, Integer>> scrollHistory = Maps.newLinkedHashMap();
+    public static final Map<AdvancementHolder, Pair<Integer, Integer>> scrollHistory = Maps.newLinkedHashMap();
 
     private final Minecraft minecraft;
     private final BetterAdvancementsScreen screen;
@@ -191,15 +191,15 @@ public class BetterAdvancementTab {
     }
 
     public void storeScroll() {
-        scrollHistory.put(this.rootNode.holder(), new Tuple<>(scrollX, scrollY));
+        scrollHistory.put(this.rootNode.holder(), Pair.of(scrollX, scrollY));
     }
 
     public void loadScroll(int width, int height) {
-        Tuple<Integer, Integer> scroll = scrollHistory.get(this.rootNode.holder());
+        Pair<Integer, Integer> scroll = scrollHistory.get(this.rootNode.holder());
         if (scroll != null) {
             this.centered = true;
-            this.scrollX = scroll.getA();
-            this.scrollY = scroll.getB();
+            this.scrollX = scroll.getFirst();
+            this.scrollY = scroll.getSecond();
 
             if (this.maxX - this.minX > width) {
                 this.scrollX = Mth.clamp(this.scrollX, -(this.maxX - width), -this.minX);

--- a/Common/src/main/java/betteradvancements/common/gui/BetterAdvancementsScreen.java
+++ b/Common/src/main/java/betteradvancements/common/gui/BetterAdvancementsScreen.java
@@ -143,7 +143,7 @@ public class BetterAdvancementsScreen extends Screen implements ClientAdvancemen
     @Override
     public boolean keyPressed(KeyEvent event) {
         if (this.minecraft.options.keyAdvancements.matches(event)) {
-            this.minecraft.setScreen(null);
+            this.minecraft.setScreenAndShow(null);
             this.minecraft.mouseHandler.grabMouse();
             return true;
         } else {

--- a/Common/src/main/java/betteradvancements/common/gui/BetterAdvancementsScreenButton.java
+++ b/Common/src/main/java/betteradvancements/common/gui/BetterAdvancementsScreenButton.java
@@ -36,7 +36,7 @@ public class BetterAdvancementsScreenButton extends AbstractButton {
 
     @Override
     public void onPress(InputWithModifiers input) {
-        Minecraft.getInstance().setScreen(new BetterAdvancementsScreen(Minecraft.getInstance().player.connection.getAdvancements()));
+        Minecraft.getInstance().setScreenAndShow(new BetterAdvancementsScreen(Minecraft.getInstance().player.connection.getAdvancements()));
     }
 
     @Override

--- a/Fabric/src/main/java/betteradvancements/mixin/MinecraftMixin.java
+++ b/Fabric/src/main/java/betteradvancements/mixin/MinecraftMixin.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(Minecraft.class)
 public class MinecraftMixin {
-    @ModifyVariable(method = "setScreen", at = @At("HEAD"), ordinal = 0, argsOnly = true)
+    @ModifyVariable(method = "setScreenAndShow", at = @At("HEAD"), ordinal = 0, argsOnly = true)
     private Screen swapAdvancementsScreen(Screen screen) {
         if (screen instanceof AdvancementsScreen) {
             Minecraft mc = Minecraft.getInstance();

--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
     "depends": {
       "fabricloader": ">=0.19",
       "fabric-api": "*",
-      "minecraft": "26.1.x",
+      "minecraft": "26.2.x",
       "java": ">=25"
     },
     "suggests": {

--- a/NeoForge/src/main/java/betteradvancements/neoforge/handler/GuiOpenHandler.java
+++ b/NeoForge/src/main/java/betteradvancements/neoforge/handler/GuiOpenHandler.java
@@ -28,7 +28,7 @@ public class GuiOpenHandler {
         if (event.getScreen() instanceof AdvancementsScreen) {
             event.setCanceled(true);
             Minecraft mc = Minecraft.getInstance();
-            mc.setScreen(new BetterAdvancementsScreen(mc.player.connection.getAdvancements()));
+            mc.setScreenAndShow(new BetterAdvancementsScreen(mc.player.connection.getAdvancements()));
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@ githubUrl=way2muchnoise/BetterAdvancements
 platforms=fabric,forge,neoforge
 
 # Minecraft
-minecraftVersion=26.1.2
-minecraftVersionRange=[26.1, 26.2)
+minecraftVersion=26.2
+minecraftVersionRange=[26.2, 26.3)
 
 # Forge
 forgeVersion=64.0.8
@@ -24,17 +24,17 @@ loaderVersionRange=[64,)
 forgeVersionRange=[64.0.0,)
 
 # Fabric
-fabricVersion=0.149.1+26.1.2
-fabricLoaderVersion=0.19.2
+fabricVersion=0.153.0+26.2
+fabricLoaderVersion=0.19.3
 
 # NeoForge
-neoforgeVersion=26.1.2.64-beta
+neoforgeVersion=26.2.0.7-beta
 neoforgeLoaderVersionRange=[4,)
-neoforgeVersionRange=[26.1.0,)
+neoforgeVersionRange=[26.2.0,)
 
 # Fabric Config screen
-clothVersion=26.1.154
-modMenuVersion=18.0.0-beta.1
+clothVersion=26.2.155
+modMenuVersion=20.0.0-beta.4
 
 # Mappings
 mappingsChannel=parchment
@@ -47,4 +47,4 @@ curseHomepageLink=https://www.curseforge.com/minecraft/mc-mods/better-advancemen
 modrinthProjectId=Q2OqKxDG
 
 # Version
-specificationVersion=0.5.0
+specificationVersion=0.5.1


### PR DESCRIPTION
fixed two really bad/breaking bugs for 26.2 update:
- used DataFixerUpper's Pair instead of net.minecraft.util.Tuple that was removed
- Minecraft.setScreen(Screen) renamed to setScreenAndShow(Screen) (updated call sites and the Fabric MinecraftMixin injection target)

dependencies for 26.2 are: NeoForge 26.2.0.7-beta, Fabric API 0.153.0+26.2, fabric-loader 0.19.3, cloth-config 26.2.155, ModMenu 20.0.0-beta.4.
also, bumped version to 0.5.1